### PR TITLE
fix(android): getStatus() return type and connection status check

### DIFF
--- a/packages/react-native-epson-escposprinter/android/src/main/java/com/epsonescposprinter/EpsonEscposprinterModule.kt
+++ b/packages/react-native-epson-escposprinter/android/src/main/java/com/epsonescposprinter/EpsonEscposprinterModule.kt
@@ -329,67 +329,9 @@ class EpsonEscposprinterModule internal constructor(val context: ReactApplicatio
   override fun getStatus(id: Double, promise: Promise) {
     coroutineScope.launch {
       runCatching {
-        getPrinter(id, promise)?.apply {
-          getStatus().let { it: PrinterStatusInfo ->
-            Arguments.createMap().apply {
-              putBoolean("connection", it.connection == Printer.TRUE)
-
-              it.online
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("online", it == Printer.TRUE) }
-
-              it.coverOpen
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("coverOpen", it == Printer.TRUE) }
-
-              it.paper
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("paper", it) }
-
-              it.paperFeed
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("paperFeed", it == Printer.TRUE) }
-
-              it.panelSwitch
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("panelSwitch", it == Printer.TRUE) }
-
-              it.drawer
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("drawer", it) }
-
-              it.errorStatus
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("errorStatus", it) }
-
-              it.autoRecoverError
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("autoRecoverError", it) }
-
-              it.buzzer
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("buzzer", it == Printer.TRUE) }
-
-              it.adapter
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("adapter", it == Printer.TRUE) }
-
-              it.batteryLevel
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("batteryLevel", it) }
-
-              it.removalWaiting
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putBoolean("removalWaiting", it == Printer.REMOVAL_WAIT_PAPER) }
-
-              it.paperTakenSensor
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("paperTakenSensor", it) }
-
-              it.unrecoverError
-                .takeIf { it != Printer.UNKNOWN }
-                ?.let { putInt("unrecoverError", it) }
-            }
+        getPrinter(id, promise)?.let { it: Printer ->
+          it.getStatus().let { it: PrinterStatusInfo ->
+            statusToObject(it)
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2866,12 +2866,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.3.4":
-  version "18.3.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.19.tgz#2b6a01315c9b1b644a8799a7d33efb027150240f"
-  integrity sha512-fcdJqaHOMDbiAwJnXv6XCzX0jDW77yI3tJqYh1Byn8EL5/S628WRx9b/y3DnNe55zTukUQKrfYxiZls2dHcUMw==
+"@types/react@^19.0.0":
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.0.tgz#73c43ad9bc43496ca8184332b111e2aef63fc9da"
+  integrity sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==
   dependencies:
-    "@types/prop-types" "*"
     csstype "^3.0.2"
 
 "@types/semver@^7.3.12":


### PR DESCRIPTION
Update the `getStatus()` method to return a `WritableMap` instead of the `Printer` instance, and add checks to prevent method calls from destroyed `Printer` instances.