### PR TITLE
feat(android): per instance mutex and global coroutineScope

### DIFF
--- a/workspaces/testprint-app/package.json
+++ b/workspaces/testprint-app/package.json
@@ -77,6 +77,7 @@
     "prettier-plugin-merge": "^0.7.2",
     "prettier-plugin-tailwindcss": "^0.6.10",
     "react-test-renderer": "19.0.0",
+    "socket.io-client": "^0.8.7",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.20.0",
     "webpack": "^5.59.0"

--- a/workspaces/testprint-app/package.json
+++ b/workspaces/testprint-app/package.json
@@ -77,7 +77,6 @@
     "prettier-plugin-merge": "^0.7.2",
     "prettier-plugin-tailwindcss": "^0.6.10",
     "react-test-renderer": "19.0.0",
-    "socket.io-client": "^0.8.7",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.20.0",
     "webpack": "^5.59.0"


### PR DESCRIPTION
To prevent printer socket congestion experienced when an HTTP server or MQTT connection is active, the following changes are to be tested:
1. Replace global mutex with a per-instance mutex
2. More functions are using said mutex
3. Replace lifecycleScope with Dispatcher.IO for coroutines